### PR TITLE
manual update to 0.1.18 release

### DIFF
--- a/Formula/chainctl.rb
+++ b/Formula/chainctl.rb
@@ -4,30 +4,30 @@
 class Chainctl < Formula
   desc "Chainguard Control"
   homepage "https://chainguard.dev"
-  version "0.1.17" # aeaae9b
+  version "0.1.18" # e49ad7e
   license "Apache-2.0"
 
   on_macos do
     if Hardware::CPU.intel?
       url "https://dl.enforce.dev/chainctl_Darwin_x86_64"
-      sha256 "7c1ee63008a5e6bad71d55de26db05e20376e5c1016bbe6c17327a913ff24e80"
+      sha256 "b0bcb83d935636af02a54b3dbda8ff2836b5c804d4ff69ede2ba3092b1ba03a9"
     end
 
     if Hardware::CPU.arm?
       url "https://dl.enforce.dev/chainctl_Darwin_arm64"
-      sha256 "5414b8c16a358c2844c350bc10767d35d03ed5f43c7bdb72381cae6de4d2ab5d"
+      sha256 "cc91b977f1f50922776a6404648fd267334ac88785ca09597f990112a67edd13"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://dl.enforce.dev/chainctl_Linux_x86_64"
-      sha256 "8ed9a91a7c02b3a9e26d560645005a6d5a6dd41c45a3a416c48101dd164e1455"
+      sha256 "0c95e49a0f87e24eb26dd536ad1c2308e1d668d2ac1302bf4b3a661cec24675d"
     end
 
     if Hardware::CPU.arm?
       url "https://dl.enforce.dev/chainctl_Linux_arm64"
-      sha256 "0175d59cede43d8a1442827a385bd02a5aa9178156d3602ab7fe56128efa8099"
+      sha256 "614cd118615bd677f04d7cda8148c4e92d0e75a5b94f25e1e8292198d451a312"
     end
   end
 


### PR DESCRIPTION
chainctl brew release failed.
manually updating.

Signed-off-by: Kenny Leung <kleung@chainguard.dev>