### PR TITLE
Revert "Brew formula update for chainctl version v0.1.104"

### DIFF
--- a/Formula/chainctl.rb
+++ b/Formula/chainctl.rb
@@ -5,20 +5,20 @@
 class Chainctl < Formula
   desc "CLI for the Chainguard Platform"
   homepage "https://chainguard.dev"
-  version "0.1.104"
+  version "0.1.103"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://dl.enforce.dev/chainctl/0.1.104/chainctl_darwin_x86_64"
-      sha256 "8391dedc5b82d44b159155db816fc3c07836beaaf588792445599e44400e9d92"
+      url "https://dl.enforce.dev/chainctl/0.1.103/chainctl_darwin_x86_64"
+      sha256 "ade7d8108b3294a4e747624acf62d4d538ae8e84bd941e5682d30efe3345b3e9"
 
       def install
         bin.install "chainctl_darwin_x86_64" => "chainctl"
       end
     end
     if Hardware::CPU.arm?
-      url "https://dl.enforce.dev/chainctl/0.1.104/chainctl_darwin_arm64"
-      sha256 "457dfd6e7ac0bc5cbcd3189977ec67573ef7f69061d536907a4bc428a7b2a1c8"
+      url "https://dl.enforce.dev/chainctl/0.1.103/chainctl_darwin_arm64"
+      sha256 "834b394d0635f8645d7500b9186340e55787ba80a103d6af48a04cfc32b298c0"
 
       def install
         bin.install "chainctl_darwin_arm64" => "chainctl"
@@ -27,20 +27,20 @@ class Chainctl < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://dl.enforce.dev/chainctl/0.1.104/chainctl_linux_arm64"
-      sha256 "01f40a041e480dc3815ed80ea772c4a63712d2c663909bd6b78e4a74a2efa7bf"
-
-      def install
-        bin.install "chainctl_linux_arm64" => "chainctl"
-      end
-    end
     if Hardware::CPU.intel?
-      url "https://dl.enforce.dev/chainctl/0.1.104/chainctl_linux_x86_64"
-      sha256 "ebee8a53fd1f7c5dd1df095e8ed9f2147dd41d897cdf3b8903870b223212c47f"
+      url "https://dl.enforce.dev/chainctl/0.1.103/chainctl_linux_x86_64"
+      sha256 "072bcc8f15a50b7ff355cd842ad7af46721396860991a2ea50e6062351f83ea2"
 
       def install
         bin.install "chainctl_linux_x86_64" => "chainctl"
+      end
+    end
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://dl.enforce.dev/chainctl/0.1.103/chainctl_linux_arm64"
+      sha256 "fb8cacd6c93b20dca9a732456eb69bf348744ce83896d6591874c91602edabea"
+
+      def install
+        bin.install "chainctl_linux_arm64" => "chainctl"
       end
     end
   end


### PR DESCRIPTION
This reverts commit 119ba274820c752b416a4045dc0e25994e3f5949.