### PR TITLE
update melange to use release v0.4.0

### DIFF
--- a/Formula/melange.rb
+++ b/Formula/melange.rb
@@ -1,20 +1,20 @@
 class Melange < Formula
   desc "Build apk packages using declarative pipelines"
   homepage "https://github.com/chainguard-dev/melange"
-  version "0.3.2"
+  version "0.4.0"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chainguard-dev/melange/releases/download/v0.3.2/melange_0.3.2_darwin_arm64.tar.gz"
-      sha256 "c5b06be8c3c40144025213a5cf8a45c53b531b7c69319e73957f4e6fb041cdf4"
+      url "https://github.com/chainguard-dev/melange/releases/download/v#{version}/melange_#{version}_darwin_arm64.tar.gz"
+      sha256 "33a8ddcd60fcd887d1f228db651eaa7e601ed3462ca1ac6a2c1649d39961ae12"
 
       def install
         bin.install "melange"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/chainguard-dev/melange/releases/download/v0.3.2/melange_0.3.2_darwin_amd64.tar.gz"
-      sha256 "3bcdae85536d25731529f21ee7f2cd6c600086d3cb1f28d1c16a5fdc4707e145"
+      url "https://github.com/chainguard-dev/melange/releases/download/v#{version}/melange_#{version}_darwin_amd64.tar.gz"
+      sha256 "360c786b89bdce169153b242cb76aef7707689570ccda252e6b65c437ef787c2"
 
       def install
         bin.install "melange"
@@ -24,16 +24,16 @@ class Melange < Formula
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chainguard-dev/melange/releases/download/v0.3.2/melange_0.3.2_linux_arm64.tar.gz"
-      sha256 "b3ac9d4f48e22a73167129116a8ca2eb54515b5d4a27bfd11a7150c6c43aaeb5"
+      url "https://github.com/chainguard-dev/melange/releases/download/v#{version}/melange_#{version}_linux_arm64.tar.gz"
+      sha256 "d39ba023640d91962df855e5a733e7935acb992bcfcd4e90d4ec2cbffffd87cf"
 
       def install
         bin.install "melange"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/chainguard-dev/melange/releases/download/v0.3.2/melange_0.3.2_linux_amd64.tar.gz"
-      sha256 "3ee61bfdc9e7c7d0b62ef454445801b70e3ec3f78541ab3b7dc82607ed2d08bd"
+      url "https://github.com/chainguard-dev/melange/releases/download/v#{version}/melange_#{version}_linux_amd64.tar.gz"
+      sha256 "d87c86935282546d6f2d5c1173f711b5919e2501722aa7458fa5b741fe13fc80"
 
       def install
         bin.install "melange"


### PR DESCRIPTION
related to https://github.com/chainguard-dev/customer-issues/issues/488