### PR TITLE
Quota GITHUB_PATH env var

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+      - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> "$GITHUB_PATH"
         if: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Set up Homebrew


### PR DESCRIPTION
I think this should fix this error:

```
     |
  14 |       - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
     |         ^~~~
  ../../../../linuxbrew/.linuxbrew/Homebrew/Library/Taps/chainguard-dev/homebrew-tap/.github/workflows/tests.yml:14:9: shellcheck reported issue in this script: SC2086:info:1:74: Double quote to prevent globbing and word splitting [shellcheck]
```