### PR TITLE
octo-sts: update melange policy to use main instead of tags

### DIFF
--- a/.github/chainguard/melange.sts.yaml
+++ b/.github/chainguard/melange.sts.yaml
@@ -1,7 +1,7 @@
 # Allow release tags from our melange repo running the release workflow to
 # push to the homebrew repo to publish melange releases.
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: repo:chainguard-dev/melange:ref:refs/tags/v.*
+subject_pattern: repo:chainguard-dev/melange:ref:refs/heads/main
 claim_pattern:
   job_workflow_ref: chainguard-dev/melange/.github/workflows/release.yaml@.*
 


### PR DESCRIPTION
Follow-up to https://github.com/chainguard-dev/melange/pull/1653

From seeing error at https://github.com/chainguard-dev/melange/actions/runs/11864609775/job/33068345713