### PR TITLE
fix(ci): add zizmor pedantic persona and suppress noisy findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 
@@ -42,3 +46,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,18 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Zizmor configuration for homebrew-tap.
+# CI runs zizmor with --pedantic; rules with no security value are disabled
+# to keep CI signal-to-noise high. See PSEC-923 for rationale.
+
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Pedantic-only; no security impact — cosmetic/style findings
+  anonymous-definition:
+    disable: true
+  # Pedantic-only; low security value but extremely noisy
+  # Address concurrency limits as a separate, dedicated effort if desired
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION

## Summary

This single-patch series adds the `persona: pedantic` configuration to the
zizmor CI workflow and suppresses noisy pedantic-only rules with no direct
security value. A Dependabot cooldown of 3 days is also configured.

One `stale-action-refs` finding requires an online check and is documented
in `manual-review.md` (per PSEC-923 campaign policy, stale-action-refs is
never auto-fixed).

## Patches

### 0001 — fix(ci): add pedantic persona and suppress noisy zizmor rules

Adds `.github/zizmor.yml` with the following configuration:

- `dependabot-cooldown: config: days: 3` — sets the expected minimum cooldown
  (1 finding: github-actions ecosystem had no cooldown configured)
- `anonymous-definition: disable: true` — pedantic-only, purely cosmetic
  (1 finding suppressed)
- `concurrency-limits: disable: true` — pedantic-only, low security value
  (3 findings suppressed across actionlint.yaml, tests.yml, zizmor.yaml)

Updates `.github/dependabot.yml` to add `cooldown: default-days: 3` to the
github-actions update block.

Updates `.github/workflows/zizmor.yaml` to:
- Pass `--pedantic` to zizmor-action
- Extend the `paths:` trigger to include `.github/dependabot.yml` and
  `.github/zizmor.yml`

## Findings addressed

| Rule | Count | Disposition |
|------|-------|-------------|
| `concurrency-limits` | 3 | Disabled in zizmor.yml (low security value) |
| `dependabot-cooldown` | 1 | cooldown: default-days: 3 added to dependabot.yml |
| `anonymous-definition` | 1 | Disabled in zizmor.yml (no security impact) |

## Manual review required

See `manual-review.md` for the `stale-action-refs` finding in `tests.yml`:
`Homebrew/actions/setup-homebrew@4e53f9c...` is pinned from a branch tip
(`# master`) rather than a tagged release. An online check is needed to
determine the correct versioned SHA.

## Testing

After merging, open a PR that modifies `.github/dependabot.yml` or
`.github/zizmor.yml` to verify the paths trigger fires. The zizmor check
should pass with zero findings (the `stale-action-refs` finding requires
a live network check and will only surface when a GH_TOKEN is available).

Refs: PSEC-923