### PR TITLE
fix(sts): pin job_workflow_ref revisions to release refs

### DIFF
--- a/.github/chainguard/dfc.sts.yaml
+++ b/.github/chainguard/dfc.sts.yaml
@@ -3,7 +3,9 @@
 issuer: https://token.actions.githubusercontent.com
 subject_pattern: repo:chainguard-dev/dfc:ref:refs/tags/v.*
 claim_pattern:
-  job_workflow_ref: chainguard-dev/dfc/.github/workflows/release.yaml@.*
+  # Constrain the workflow revision to the same v* tag refs the subject
+  # requires; `@.*` would accept the workflow from any ref.
+  job_workflow_ref: chainguard-dev/dfc/.github/workflows/release.yaml@refs/tags/v.*
 
 permissions:
   contents: write

--- a/.github/chainguard/melange.sts.yaml
+++ b/.github/chainguard/melange.sts.yaml
@@ -3,7 +3,9 @@
 issuer: https://token.actions.githubusercontent.com
 subject_pattern: repo:chainguard-dev/melange:ref:refs/heads/main
 claim_pattern:
-  job_workflow_ref: chainguard-dev/melange/.github/workflows/release.yaml@.*
+  # Constrain the workflow revision to main, matching the subject;
+  # `@.*` would accept the workflow from any ref.
+  job_workflow_ref: chainguard-dev/melange/.github/workflows/release.yaml@refs/heads/main
 
 permissions:
   contents: write

--- a/.github/chainguard/mono.sts.yaml
+++ b/.github/chainguard/mono.sts.yaml
@@ -3,7 +3,11 @@
 issuer: https://token.actions.githubusercontent.com
 subject_pattern: repo:chainguard-dev/mono:ref:refs/tags/v.*
 claim_pattern:
-  job_workflow_ref: chainguard-dev/mono/.github/workflows/.release-drop.yaml@.*
+  # Constrain the workflow revision to the same v* tag refs the subject
+  # requires; `@.*` would accept the workflow from any ref. The release
+  # drop workflow is a local reusable workflow, so its revision is the
+  # calling provision run's tag ref.
+  job_workflow_ref: chainguard-dev/mono/.github/workflows/.release-drop.yaml@refs/tags/v.*
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Tighten the STS policies by pinning each `job_workflow_ref` to the same ref its `subject_pattern` already requires, instead of the `@.*` wildcard. This matches the convention used by other pinned octo-sts policies.

| Policy | Before | After |
|---|---|---|
| `dfc.sts.yaml` | `@.*` | `@refs/tags/v.*` |
| `melange.sts.yaml` | `@.*` | `@refs/heads/main` |
| `mono.sts.yaml` | `@.*` | `@refs/tags/v.*` |

A ref pattern (rather than a commit SHA) is used because GitHub sets the `job_workflow_ref` revision to the triggering git ref for directly triggered and locally called reusable workflows.

## Verified against upstream triggers

Each upstream release workflow's trigger was checked so the tightened patterns continue to match legitimate release runs (dfc: `v*` tag push; melange: schedule/dispatch on `main`; mono: local reusable workflow called from tag-triggered runs).

## Test plan

- [ ] Next dfc/melange/mono release publishes to the tap successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)